### PR TITLE
Update Github CI node versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 15
+          node-version: 17
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
       - name: Check lint
         run: yarn run lint --no-fix
   full:
-    name: Node.js 15 Full
+    name: Node.js 17 Full
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
@@ -28,7 +28,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 15
+          node-version: 17
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
       - name: Run tests
@@ -38,6 +38,7 @@ jobs:
     strategy:
       matrix:
         node-version:
+          - 16
           - 14
           - 12
     name: Node.js ${{ matrix.node-version }} Quick


### PR DESCRIPTION
This PR updates the node versions on which this dependencies is tested:
* Node 15 is removed since it is no longer supported
* Node 16 and 17 are added.