### PR TITLE
Make Tailwind rebuilds css when file in `content` changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
-const postcss = require("postcss");
 const path = require("path");
 const fs = require("fs");
+
+const setupTrackingContext =
+  require("tailwindcss/lib/lib/setupTrackingContext").default;
+const processTailwindFeatures =
+  require("tailwindcss/lib/processTailwindFeatures").default;
 
 module.exports = (opts = {}) => {
   /*
@@ -46,8 +50,9 @@ module.exports = (opts = {}) => {
       throw new Error(`Cannot find config file '${file}'`);
     }
 
-    const tailwindcss = require("tailwindcss")(file);
-    return postcss(tailwindcss.plugins).process(root, { from: undefined });
+    // This part replicates the structure in tailwindcss/lib/index.js
+    // We need to do this to make sure all files are tracked and declared
+    processTailwindFeatures(setupTrackingContext(file))(root, result);
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "postcss": "^8.2.8",
-    "tailwindcss": "^2.0.0 || ^3.0.0"
+    "tailwindcss": "^3.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.2.5",


### PR DESCRIPTION
Fix #128 

This PR fixes an issue where webpack/postcss-cli/... would rebuild, but the output from tailwindcss would stay the same.

Due to the way we included Tailwind, our postcss `result` wasn't aware that it should track changes in the files that are declared in Tailwind's config.content.

Since we now mirror the internal structure of tailwindcss/lib/index.js and we use some of their internal functions, this PR will drop support for Tailwindcss 2.x